### PR TITLE
plugins/pulsar-authentication-plugin: add option to ignore aud

### DIFF
--- a/plugins/pulsar-authentication-plugin/src/test/java/com/krafton/sbx/plugins/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDIntegrationTest.java
+++ b/plugins/pulsar-authentication-plugin/src/test/java/com/krafton/sbx/plugins/pulsar/broker/authentication/oidc/AuthenticationProviderOpenIDIntegrationTest.java
@@ -18,24 +18,38 @@
  */
 package com.krafton.sbx.plugins.pulsar.broker.authentication.oidc;
 
+import com.auth0.jwt.JWT;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultJwtBuilder;
+import io.jsonwebtoken.security.Keys;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.asserts.Assertion;
 
 import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Date;
 import java.util.Properties;
 import java.util.Set;
 
 // TODO: populate issuer, jwt field
 public class AuthenticationProviderOpenIDIntegrationTest {
-
+    PrivateKey privateKey;
+    PublicKey publicKey;
     AuthenticationProviderOpenID provider;
     String issuer;
 
     @BeforeClass
     void beforeClass() throws IOException {
         issuer = "<issuer here>";
+
+        var keyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
+        privateKey = keyPair.getPrivate();
+        publicKey = keyPair.getPublic();
 
         ServiceConfiguration conf = new ServiceConfiguration();
         conf.setAuthenticationEnabled(true);
@@ -44,6 +58,7 @@ public class AuthenticationProviderOpenIDIntegrationTest {
         props.setProperty(AuthenticationProviderOpenID.DISCOVERY_ISSUER, issuer);
         props.setProperty(AuthenticationProviderOpenID.FALLBACK_DISCOVERY_MODE, FallbackDiscoveryMode.HTTP_DISCOVER_TRUSTED_ISSUER.name());
         props.setProperty(AuthenticationProviderOpenID.ALLOWED_AUDIENCES, "https://kubernetes.default.svc");
+        props.setProperty(AuthenticationProviderOpenID.ALLOWED_EMPTY_AUD_ISSUERS, "kubernetes/serviceaccount");
 
         provider = new AuthenticationProviderOpenID();
         provider.initialize(conf);
@@ -54,5 +69,32 @@ public class AuthenticationProviderOpenIDIntegrationTest {
         var jwt = "<jwt here>";
 
         provider.authenticateAsync(new AuthenticationDataCommand(jwt)).get();
+    }
+
+    @Test
+    public void testNullAudClaimForAllowedIssuer() throws Exception {
+        var jwt = this.generateToken("kubernetes/serviceaccount");
+
+        var decodedJwt = JWT.decode(jwt);
+        provider.verifyJWT(this.publicKey, "RS256", decodedJwt);
+
+        var jwt2 = this.generateToken("unknown-issuer");
+        var decodedJwt2 = JWT.decode(jwt2);
+        Assert.assertThrows(() -> provider.verifyJWT(this.publicKey, "RS256", decodedJwt2));
+    }
+
+    private String generateToken(String issuer) {
+        var now = System.currentTimeMillis();
+
+        var builder = new DefaultJwtBuilder();
+
+        builder.signWith(this.privateKey);
+        builder.setIssuer(issuer);
+        builder.setIssuedAt(new Date());
+        builder.setExpiration(new Date(now + 99999999));
+        builder.setNotBefore(new Date());
+        builder.setSubject("system:serviceaccount:default:default");
+
+        return builder.compact();
     }
 }


### PR DESCRIPTION
add `aud` claim ignore if the configured issuer-signed jwt.

use case: allow serviceaccount -> secret projected token